### PR TITLE
CI: get fullname when syncing GitHub-CERN mapping

### DIFF
--- a/ci/sync-mapusers.py
+++ b/ci/sync-mapusers.py
@@ -23,6 +23,15 @@ except Exception:
 
 # Update current mapping with new
 umap = yaml.safe_load(open("mapusers.yml"))
+pending_maps = get(url).json()["login_mapping"]
+for k in pending_maps:
+  if isinstance(pending_maps[k], dict):
+    for j in umap:
+      if not isinstance(umap[j], dict):
+        # Server has new format, file has old. Convert
+        umap = { x:{"user_github":umap[x],"fullname":umap[x]} for x in umap }
+      break
+  break
 umap.update( get(url).json()["login_mapping"] )
 for k in sorted(umap.keys()):
   print("%s: %s" % (k, umap[k]))


### PR DESCRIPTION
Goes together with alisw/alice-github#6 and it is backwards-compatible. I am
merging this one, and the moment alisw/alice-github#6 is merged then the new
format will be immediately adopted.

Currently mapped users will have to re-register.

Note: I have tested it using Marathon's `test-alice-github` instance.